### PR TITLE
Faster Kernel calculation using a C library

### DIFF
--- a/models_paper_SVMvsDL/Makefile
+++ b/models_paper_SVMvsDL/Makefile
@@ -1,0 +1,20 @@
+CC=gcc
+CFLAGS=-fPIC -shared
+OBJECTS=strkernel.so
+.PHONY: wdkernel
+.PHONY: strkernel
+
+wdkernel: strkernel.so
+	@echo "\nTesting the performance of WD kernel calculation"
+	python WDKernel.py
+
+strkernel:
+	@echo "\nTesting the performance of string kernel in C"
+	gcc strkernel.c
+	mv a.out ~
+	chmod +x ~/a.out
+	~/a.out
+
+%.so: %.c
+	@echo Compiling shared library
+	$(CC) $(CFLAGS) $< -o $@

--- a/models_paper_SVMvsDL/WDKernel.py
+++ b/models_paper_SVMvsDL/WDKernel.py
@@ -1,22 +1,158 @@
 import numpy as np
-import itertools
-from multiprocessing import Pool #  Process pool
+from multiprocessing import Pool  # Process pool
 from multiprocessing import sharedctypes
 from itertools import groupby
 
+import sys
+import ctypes as ct
 
+RED = "\033[1m\033[91m"
+GREEN = "\033[1m\033[92m"
+END = "\033[0m"
+
+
+#   #    #                                                       #
+#   #   #       #    #    ##    #       #    #  ######   ####    #
+#   #  #        #    #   #  #   #       #    #  #       #        #
+#   ###         #    #  #    #  #       #    #  #####    ####    #
+#   #  #        #    #  ######  #       #    #  #            #   #
+#   #   #        #  #   #    #  #       #    #  #       #    #   #
+#   #    #        ##    #    #  ######   ####   ######   ####    #
+
+
+# ###########################--------------------------------------------------
+#                           #
+#  LOAD THE SHARED LIBRARY  #
+#                           #
+#############################
+
+try:
+    lib = ct.CDLL("./strkernel.so")
+except Exception:
+    print(f"{RED}Library strkernel.so not found.{END}")
+    print(f"{RED}Compile it first with:{END}")
+    print(f"{GREEN}   gcc -fPIC -shared strkernel.c -o strkernel.so{END}")
+    print("or:")
+    print(f"{GREEN}   make strkernel{END}")
+    sys.exit(-1)
+
+charptr = ct.POINTER(ct.c_char)
+
+# long double cgo_get_K_value1(char *xi, char *xj, int L, int d)
+lib.cgo_get_K_value1.argtypes = [charptr, charptr, ct.c_int, ct.c_int]
+lib.cgo_get_K_value1.restype = ct.c_longdouble
+cgo_get_K_value1 = lib.cgo_get_K_value1
+
+# long double cgo_get_K_value2(char *xi, char *xj, int L, int d)
+lib.cgo_get_K_value2.argtypes = [charptr, charptr, ct.c_int, ct.c_int]
+lib.cgo_get_K_value2.restype = ct.c_longdouble
+cgo_get_K_value2 = lib.cgo_get_K_value2
+
+wcharptr = np.ctypeslib.ndpointer(dtype='<U1', ndim=1, flags="C")
+
+# long double new_cgo_get_K_value(const wchar_t *xi, const wchar_t *xj, int L, int d)
+lib.cgo_get_K_value3.argtypes = [wcharptr, wcharptr, ct.c_int, ct.c_int]
+lib.cgo_get_K_value3.restype = ct.c_longdouble
+cgo_get_K_value3 = lib.cgo_get_K_value3  # 👈 this is the preferred method
+
+# -----------------------------------------------------------------------------
+
+
+# CGO: número de valores parece finito y bajo, quizás mejor precalcularla.
+# Alternativamente se podría decorar con functools.cache
 def beta_k(d, k):
-    # Formula from https://www.jmlr.org/papers/volume7/sonnenburg06a/sonnenburg06a.pdf
+    # SEE: https://www.jmlr.org/papers/volume7/sonnenburg06a/sonnenburg06a.pdf
     return 2*((d-k+1)/(d*(d+1)))
 
 
+def old_get_K_value(xi, xj, L, d, DEBUG=False):
+    # 🔴  is expecting that xi and xj are strings
+    # SEE: https://www.jmlr.org/papers/volume7/sonnenburg06a/sonnenburg06a.pdf
+    # First SUM
+    E1 = 0
+    for k in range(1, d+1):
+        if DEBUG:
+            print(f"***k: {k}")
+        beta = beta_k(d, k)
+        # Second SUM
+        E2 = 0
+        if DEBUG:
+            print(f"range(L-k+1) => range({L}-{k}+1) ", end="")
+            print(f"=> range({L-k+1}) => {list(range(L-k+1))}")
+        for l in range(L-k+1):  # Aquí no sumo 1 a cada lado del range porque son posiciones de una lista
+            if DEBUG:
+                print(f"l: {l}")
+            if DEBUG:
+                print(f"xi: {xi}", end=", ")
+                print(f"xi[{l}:{l+k}]: {xi[l:l+k]}", end=", ")
+                print(f"xj[{l}:{l+k}]: {xj[l:l+k]}")
+                if xi[l:l+k] == xj[l:l+k]:
+                    print("+1")
+            E2 += int(xi[l:l+k] == xj[l:l+k])
+        E1 += beta * E2
+        if DEBUG:
+            print(f"E2: {E2}, E1: {E1}")
+    return E1
+
+
+def get_K_value(xi, xj, L, d):
+    # Versión optimizada (mucho menos legible)
+    # Más rápida en cadenas largas. Más lenta en cortas.
+    E1 = 0
+    groups = groupby(xi == xj)  # Para comparar carácter a carácter
+    result = [(label, sum(1 for _ in group))
+              for label, group in groups if label]
+    E1 = np.zeros(d)
+    for k in range(1, d+1):
+        e1 = 0
+        for _, n in result:
+            if n >= k:
+                e1 += n+1-k
+        E1[k-1] = e1 * beta_k(d, k)
+    return E1.sum()
+
+
+Kvalue = cgo_get_K_value3  # 👈 👈  Default value for Kvalue
+
+
+#   #    #                                            #
+#   #   #   ######  #####   #    #  ######  #         #
+#   #  #    #       #    #  ##   #  #       #         #
+#   ###     #####   #    #  # #  #  #####   #         #
+#   #  #    #       #####   #  # #  #       #         #
+#   #   #   #       #   #   #   ##  #       #         #
+#   #    #  ######  #    #  #    #  ######  ######    #
+#                                                     #
+#   #    #    ##    #####  #####   #  #    #          #
+#   ##  ##   #  #     #    #    #  #   #  #           #
+#   # ## #  #    #    #    #    #  #    ##            #
+#   #    #  ######    #    #####   #    ##            #
+#   #    #  #    #    #    #   #   #   #  #           #
+#   #    #  #    #    #    #    #  #  #    #          #
+
+
 def fill_per_window_same_matrix(args):
-    # Si son iguales solo hace falta recorrer media matriz, la otra mitad tiene los mismos resultados
+    # Si son iguales solo hace falta recorrer media matriz,
+    # la otra mitad tiene los mismos resultados
+    global Kvalue  # It is not modified, but this highlights it is a global
     inirow, endrow = args
     tmp = np.ctypeslib.as_array(shared_array)
     for idx_x in range(inirow, endrow):
         for idx_y in range(idx_x, n_cols):
-            tmp[idx_x, idx_y] = get_K_value(X1_g[idx_x], X2_g[idx_y], L, d_g)
+            tmp[idx_x, idx_y] = Kvalue(X1_g[idx_x], X2_g[idx_y], L, d_g)
+            tmp[idx_y, idx_x] = tmp[idx_x, idx_y]
+
+
+def fill_per_window_same_matrix_with_cgo_get_K_value_version1(args):
+    # This is just the previous function but calling
+    # cgo_get_K_value1 which requires char strings as inputs
+    inirow, endrow = args
+    tmp = np.ctypeslib.as_array(shared_array)
+    for idx_x in range(inirow, endrow):
+        for idx_y in range(idx_x, n_cols):
+            tmp[idx_x, idx_y] = cgo_get_K_value1(''.join(X1_g[idx_x]).encode(),
+                                                 ''.join(X2_g[idx_y]).encode(),
+                                                 L, d_g)
             tmp[idx_y, idx_x] = tmp[idx_x, idx_y]
 
 
@@ -25,14 +161,11 @@ def fill_per_window_different_matrix(args):
     tmp = np.ctypeslib.as_array(shared_array)
     for idx_x in range(inirow, endrow):
         for idx_y in range(n_cols):
-            tmp[idx_x, idx_y] = get_K_value(X1_g[idx_x], X2_g[idx_y], L, d_g)
-        
-                
+            tmp[idx_x, idx_y] = Kvalue(X1_g[idx_x], X2_g[idx_y], L, d_g)
 
-def parallel_wdkernel_gram_matrix(X1, X2):
+
+def parallel_wdkernel_gram_matrix(X1, X2, ncores=20, d=10):
     # https://jonasteuwen.github.io/numpy/python/multiprocessing/2017/01/07/multiprocessing-numpy-array.html
-    
-    d = 10
 
     # Needed for multiprocessing
     global X1_g
@@ -45,10 +178,10 @@ def parallel_wdkernel_gram_matrix(X1, X2):
     global n_cols
     X1_g = X1
     X2_g = X2
-    #X1_g = np.array(list(X1))
-    #X2_g = np.array(list(X2))
-    print('X1', X1.shape)
-    print('X2', X2.shape)
+    # X1_g = np.array(list(X1))
+    # X2_g = np.array(list(X2))
+    # print('X1', X1.shape)
+    # print('X2', X2.shape)
     d_g = d
     L = len(X1[0])
     n_rows = X1.shape[0]
@@ -60,23 +193,62 @@ def parallel_wdkernel_gram_matrix(X1, X2):
         fill_per_window = fill_per_window_different_matrix
 
     # Divide the matrix by rows
-    cores = 20
+    cores = ncores
     block_size = int(n_rows/cores) + 1
-    rows = [(startrow, startrow+block_size) if startrow+block_size <= n_rows  else (startrow, n_rows) for startrow in range(0, n_rows, block_size)]
+    rows = [(startrow, startrow+block_size)
+            if startrow+block_size <= n_rows else
+            (startrow, n_rows)
+            for startrow in range(0, n_rows, block_size)]
 
     # Shared array
-    K = np.ctypeslib.as_ctypes(np.zeros((n_rows, n_cols)))      
+    K = np.ctypeslib.as_ctypes(np.zeros((n_rows, n_cols)))
     shared_array = sharedctypes.RawArray(K._type_, K)
-    
-    #print(rows)
+
+    # print(rows)
     p = Pool()
-    res = p.map(fill_per_window, rows)
+    _ = p.map(fill_per_window, rows)
     result = np.ctypeslib.as_array(shared_array)
 
     return result
-    
 
-def wdkernel_gram_matrix(X1, X2):
+
+def parallel_wdkernel_gram_matrix_with_cgo_get_K_value_version1(X1, X2, ncores=20, d=10):
+    # This is just the previous function but calling
+    # fill_per_window_same_matrix_with_cgo_get_K_value_version1
+    # instead of fill_per_window_same_matrix
+    global X1_g
+    global X2_g
+    global d_g
+    global L
+    global block_size
+    global shared_array
+    global n_rows
+    global n_cols
+    X1_g = X1
+    X2_g = X2
+    d_g = d
+    L = len(X1[0])
+    n_rows = X1.shape[0]
+    n_cols = X2.shape[0]
+    if X1_g is X2_g:
+        fill_per_window = fill_per_window_same_matrix_with_cgo_get_K_value_version1
+    else:
+        fill_per_window = fill_per_window_different_matrix
+    cores = ncores
+    block_size = int(n_rows/cores) + 1
+    rows = [(startrow, startrow+block_size)
+            if startrow+block_size <= n_rows else
+            (startrow, n_rows)
+            for startrow in range(0, n_rows, block_size)]
+    K = np.ctypeslib.as_ctypes(np.zeros((n_rows, n_cols)))
+    shared_array = sharedctypes.RawArray(K._type_, K)
+    p = Pool()
+    _ = p.map(fill_per_window, rows)
+    result = np.ctypeslib.as_array(shared_array)
+    return result
+
+
+def wdkernel_gram_matrix(X1, X2, d=10):
     '''
     Gets the gram matrix between X1 and X2.
     https://stackoverflow.com/questions/26962159/how-to-use-a-custom-svm-kernel
@@ -94,48 +266,229 @@ def wdkernel_gram_matrix(X1, X2):
     E1 = First summatory in the formula
     E2 = Second summatory in the formula
     '''
+    global Kvalue  # It is not modified, but this highlights it is a global
 
     N1 = X1.shape[0]
     N2 = X2.shape[0]
     L = len(X1[0])
-    d = 3
 
     K = np.zeros((N1, N2))
 
     for i in range(N1):
         for j in range(N2):
-            print(f'{N2*i+j:,}/{N1*N2:,}', end='\r', flush=True)
-            K[i, j] = get_K_value(X1[i], X2[j], L, d)
+            # print(f'{N2*i+j:,}/{N1*N2:,}', end='\r', flush=True)
+            K[i, j] = Kvalue(X1[i], X2[j], L, d)
 
     return K
 
 
-def old_get_K_value(xi, xj, L, d):
-    # Formula from https://www.jmlr.org/papers/volume7/sonnenburg06a/sonnenburg06a.pdf
-    # First SUM
-    E1 = 0
-    for k in range(1, d+1):
-        beta = beta_k(d, k)
-        # Second SUM
-        E2 = 0
-        for l in range(L-k+1):  #Aquí no sumo 1 a cada lado del range porque son posiciones de una lista
-            E2 += int(xi[l:l+k] == xj[l:l+k])
-        E1 += beta * E2
-    return E1
+def wdkernel_gram_matrix_with_cgo_get_K_value_version1(X1, X2, d=10):
+    # This is just the previous function but calling
+    # cgo_get_K_value1 which requires char strings as inputs
+    N1 = X1.shape[0]
+    N2 = X2.shape[0]
+    L = len(X1[0])
+    K = np.zeros((N1, N2))
+    for i in range(N1):
+        for j in range(N2):
+            K[i, j] = cgo_get_K_value1(''.join(X1[i]).encode(),
+                                       ''.join(X2[j]).encode(), L, d)
+    return K
 
 
-def get_K_value(xi, xj, L, d):
-    # Versión optimizada (mucho menos legible)
-    # Más rápida en cadenas largas. Más lenta en cortas.
-    E1 = 0
-    groups = groupby(xi == xj) # Para comparar caracter a caracter
-    result = [(label, sum(1 for _ in group)) for label, group in groups if label]
-    E1 = np.zeros(d)
-    for k in range(1, d+1):
-        e1 = 0
-        for _, n in result:
-            if n >= k:
-                e1 += n+1-k
-        E1[k-1] = e1 * beta_k(d, k)
-    return E1.sum()
-    
+#    #######                                    #
+#       #     ######   ####   #####   ####      #
+#       #     #       #         #    #          #
+#       #     #####    ####     #     ####      #
+#       #     #            #    #         #     #
+#       #     #       #    #    #    #    #     #
+#       #     ######   ####     #     ####      #
+                                        
+
+SEQ1 = "CGGTACACGACGGTGTGACCTGTGATGCGGCAGGAAGCCGCTCCCATGCCTTCCGCTAAATTATACGAGACGAGCGGTTAGGCACATAATTGAATCTGCTGCTGTCGATCGCTAAGCATCCGACTCGTGAATCATATAAACATGTCTACTTATGATCAATCAATCCCCCCTCACATTGAATCCGAGCTCCGTGACATCACATGGGATTTCGTAATTTGCATGTGACGACAGCAGTCCTACCCCATTTGCCTGAGCTATTTGTGGCACGGATAGCCCGCTCCTACGCCTGGTTTCTTACTACGCTGCGCGAAGGTCGTCTTTGGCTCTACAGACTGGTCTTGACCGGCCCTTCCAGATAGAGGCCGGACAGCGTGGCCTCTTCATGCGAAAATTCGGCAGGAGGGGTAGGGACGGGGACAATAGACAGCCATCTATCGTAGAAAACCCCACTGACTGGGATGGACCAGCAGCTGGGAGCTAGACCGAGGAAGCAGTCCGACCCGAGGTAGCCTCTGCTCGCCCGCGGCTGCACCGGAGGACTTTACAGTGGAATTCAAGTATCAGATAACTTGGTGTCGTCTACTCAGAGAACTTAATTACAATATCCTACCCCGCCCCGAGGCAATTGTTCTAGTTAGAGCCTAATCTACGTGTAGGGCGACGAGTACTTATTGGCCAGCATAGCTGGTAGCCTATCGGGGGTTCCATCGAACCACGGCTATCGCAGTACATGAACAAATGACCCGCCTGCATACTAACGGTCTCTATGAAACAAATTTATACTTAGTGATATCTACCATCTAAAGTTCGGCTCTAACTGTTCGCCGTCCGATAAGTGCTCGGAGGCGTGCAACAGGCCCAACCGTGAAGACCTTTAACCCATCCAAGACTATGTGCGGAATGGTTATGCACGCACGTATCGTCATGCCCTTTCGATTCCCTCGGCTCTCGCAAACGGAGTCCGTAGGCGAAGCGCGCGATGAAGGTAGGGGACGGAACCTGT"
+
+SEQ2 = "ACGACCCGTGGGATTCTCTTTCTCCACAATTCACTGGGCCTTTAACCCGAATAACCTTCGATCGCTCCTACATCTTTTAGCTCCGCACTTGCGTTAGCGTAGAGGGGGCACCCGCTTTGCGGCGACCATCCAACTTCGTAGCTTGGTCGCGTGCGACAATGTCTCTACACTCACTGGAGATTGGCCTACAGCACTACCTATACACGGGGGAGCATCCCTAAAGCCTTTCCCTTGTCTGGGAGCCGCGGCGAATTCGAAGACTAGAGACTAGTAGCCGGATAGTCCGCAAGGAGCTCATTGCTGCACGAAACTAAACTCTCAAACCGCCCAAAAGTGATATCGAGATGCTGCACACTCAAGCTGACTACCCGGTTTCAGTATGTACACTGATAGCGATTACTAATCAACCCAGTACGTTGTTAGGATATCAATCGGTTTGCGTTGATGGACAGCGGCGGCAAATCCGGACATTATCAAACATAAGTCAGGTCTGTCCCGGCAGGGTGATCGGCCTCTGCCTAAGAATGGGGATCTGGATTGGCCACTGAAGATGAAGTTCTGTGTAAAAATGCTGTGTTCGCCACAATACTGCTGTGTCGTCGAGATGCGGCAGTTGGGATCTTACCCACACTCCGGCGACGTGGAGATCCTTTATTGGCGTACTCGCCGACTATTCGGTGAGGACGATAACCCTTGTGCTCAGCTCCGGATACGTAATCCCTAGGAGAGTTCTTCTCTCTTGAACTGTTATCGGGTACTGCCGTACTCGCATGGCCGGTGCGATTATCCCAGTCCCCTAAGAACCAGATGTTGTACGGCGACCTAGGGGCGAGCGTTTTTTGTGACAATATCCACTAGCCTGATCGCATGTTAGGAGTAGGACTACTATTACACCGGCGTTACTAGGTAAATTTGGATAGGGTTTGCGGTAGCACAGACATAAACAGGACACAAGATGGTCTACCCACTACTCGCATTGGACCTGATGGTCGCGTCCACTATC"
+
+
+def genseq(length):
+    import random
+    return ''.join(random.choice('CGTA') for _ in range(length))
+
+
+def genseqs(numseqs, length):
+    return np.array([list(genseq(length)) for _ in range(numseqs)])
+
+# SEQ1 = genseq(4000)
+# SEQ2 = genseq(4000)
+
+
+def test1():
+    darray = (1, 2, 4)
+    karray = (3, 4, 5)
+    for d in darray:
+        for k in karray:
+            print(f"beta_k({d}, {k}): {beta_k(d, k)}")
+
+
+def test2():
+    import time
+    print("Running")
+    xi = SEQ1
+    xj = SEQ2
+    d = 800
+    # xi, xj, d = "AAGGTT", "AGGTTT", 2
+    # xi, xj, d = "AAGGTTAAGGTT", "AGGTTTAGGTTT", 10
+    L = len(xi)
+    print(f"L: {L}, d: {d}")
+    start = time.time()
+    res = old_get_K_value(xi, xj, L, d)
+    end1 = time.time() - start
+    print(f"Result is {res} in {end1} seconds.")
+
+    xi = np.array(list(SEQ1))  # 👈 outside of the timing as it will be the native format
+    xj = np.array(list(SEQ2))
+    start = time.time()
+    res = get_K_value(xi, xj, L, d)
+    end2 = time.time() - start
+    print(f"Result is {res} in {end2} seconds.")
+
+    print(f"Version with NumPy is {end1/end2} faster than old version.")
+
+
+def test3():
+    import time
+
+    # xi, xj, d = "AAGGTT", "AGGTTT", 2
+    # xi, xj, d = "AAGGTTAAGGTT", "AGGTTTAGGTTT", 10
+
+    seq1 = SEQ1*100
+    seq2 = SEQ2*100
+
+    d = 200
+    L = len(seq1)
+    print(f"L: {L}, d: {d}")
+
+    xi = seq1
+    xj = seq2
+    start = time.time()
+    res = old_get_K_value(xi, xj, L, d)
+    endOld = time.time() - start
+    print(f"Pyth result is {res} in {endOld:.15f} seconds.")
+
+    xi = np.array(list(seq1))  # 👈 outside of the timing as it will be the native format
+    xj = np.array(list(seq2))
+    start = time.time()
+    res = get_K_value(xi, xj, L, d)
+    endNumpy = time.time() - start
+    print(f"P.np result is {res} in {endNumpy:.15f} seconds.")
+
+    start = time.time()
+    xi = seq1.encode()  # 👈 inside the timing as v1 need char strings
+    xj = seq2.encode()
+    res = cgo_get_K_value1(xi, xj, L, d)
+    endCv1 = time.time() - start
+    print(f"C.v1 result is {res} in {endCv1:.15f} seconds.")
+
+    start = time.time()
+    xi = seq1.encode()  # 👈 inside the timing as v2 need char strings
+    xj = seq2.encode()
+    res = cgo_get_K_value2(xi, xj, L, d)
+    endCv2 = time.time() - start
+    print(f"C.v2 result is {res} in {endCv2:.15f} seconds.")
+
+    xi = np.array(list(seq1))  # 👈 outside of the timing as it will be the native format
+    xj = np.array(list(seq2))
+    start = time.time()
+    res = cgo_get_K_value3(xi, xj, L, d)
+    endCv3 = time.time() - start
+    print(f"C.v3 result is {res} in {endCv3:.15f} seconds.")
+
+    print()
+    print(f"{GREEN}Python.np is {endOld/endNumpy:.3f} times faster than Python!!!{END}")
+    print(f"C.v1 is {endNumpy/endCv1:.3f} times faster than Python.np!!!")
+    print(f"C.v2 is {endNumpy/endCv2:.3f} times faster than Python.np!!!")
+    print(f"{GREEN}C.v3 is {endNumpy/endCv3:.3f} times faster than Python.np{END}!!!")
+    print(f"With d={d}, C.v2 implementation was {endCv1/endCv2:.3f} faster than C.v1.")  
+    print()
+    print("It is not clear which C.v1 or C.v2 is faster (it depends on L and d).")
+    print("C.v3 is marginally better than the others (but again, it depends on L and d).")
+
+
+def test4():
+    "Test times and that the result are the same for all implementations."
+    import time
+    global Kvalue
+    oldKvalue = Kvalue
+
+    CORES = 4
+    d = 10
+    L = 1003
+    nseqs = 500
+    X1 = genseqs(nseqs, L)
+    print(f"nseqs: {nseqs}, L: {L}, d: {d}")
+
+    start = time.time()
+    Kvalue = get_K_value  # 👈 change global Kvalue
+    res = wdkernel_gram_matrix(X1, X1, d=d)
+    Kvalue = oldKvalue
+    endPyNumpy = time.time() - start
+    print(f"Python.np result is {res.sum()} in {endPyNumpy} seconds.")
+    print(res.sum(axis=0)[:5])
+    print()
+
+    start = time.time()
+    res = wdkernel_gram_matrix_with_cgo_get_K_value_version1(X1, X1, d=d)
+    endCv1 = time.time() - start
+    print(f"C.v1 result is {res.sum()} in {endCv1} seconds.")
+    print(res.sum(axis=0)[:5])
+    print()
+
+    start = time.time()
+    Kvalue = cgo_get_K_value3  # 👈 change global Kvalue
+    res = wdkernel_gram_matrix(X1, X1, d=d)
+    Kvalue = oldKvalue
+    endCv3 = time.time() - start
+    print(f"C.v3 result is {res.sum()} in {endCv3} seconds.")
+    print(res.sum(axis=0)[:5])
+    print()
+
+    start = time.time()
+    Kvalue = get_K_value  # 👈 change global Kvalue
+    res = parallel_wdkernel_gram_matrix(X1, X1, ncores=CORES, d=d)
+    Kvalue = oldKvalue
+    endPyNumpyPar = time.time() - start
+    print(f"Python.par result is {res.sum()} in {endPyNumpyPar} seconds.")
+    print(res.sum(axis=0)[:5])
+    print()
+
+    start = time.time()
+    res = parallel_wdkernel_gram_matrix_with_cgo_get_K_value_version1(X1, X1, ncores=CORES, d=d)
+    endCParv1 = time.time() - start
+    print(f"C.par.v1 result is {res.sum()} in {endCParv1} seconds.")
+    print(res.sum(axis=0)[:5])
+    print()
+
+    start = time.time()
+    Kvalue = cgo_get_K_value3  # 👈 change global Kvalue
+    res = parallel_wdkernel_gram_matrix(X1, X1, ncores=CORES, d=d)
+    Kvalue = oldKvalue
+    endCParv3 = time.time() - start
+    print(f"C.par.v3 result is {res.sum()} in {endCParv3} seconds.")
+    print(res.sum(axis=0)[:5])
+    print()
+
+    print(f"nseqs: {nseqs}, L: {L}, d: {d}")
+    print()
+    print(f"C.v1 is {endPyNumpy/endCv1:.3f} times faster than Python.np")
+    print(f"C.v3 is {endPyNumpyPar/endCParv3:.3f} times faster than Python.np")
+    print()
+    print(f"C.par.v3 is {endPyNumpy/endCParv3:.3f} times faster than Python.np")
+    print(f"{GREEN}C.par.v3 is {endPyNumpyPar/endCParv3:.3f} times faster than Python.par{END}")
+    print()
+    print(f"C.par.v3 is {endCv3/endCParv3:.3f} times faster than C.v3")
+    print(f"{GREEN}Python.par is {endPyNumpy/endPyNumpyPar:.3f} times faster than Python.np{END}")
+
+
+if __name__ == '__main__':
+    test4()
+    print()

--- a/models_paper_SVMvsDL/strkernel.c
+++ b/models_paper_SVMvsDL/strkernel.c
@@ -1,0 +1,210 @@
+/**
+ * Author:      César Ignacio García Osorio (cgosorio@ubu.es)
+ * Created:     11/Oct/2022
+ * Description: Implementation of the weighted degree string kernel as
+ * described in https://www.jmlr.org/papers/volume7/sonnenburg06a/sonnenburg06a.pdf
+ *
+ **/
+
+#include <stdio.h>  // printf(), fpring(), stderr
+#include <string.h> // strlen(), strcat()
+#include <stddef.h> // size_t, wchar_t
+#include <time.h>   // clock_t, clock(), CLOCKS_PER_SEC
+#include <wchar.h>  // wchar_T, mbstowcs()
+#include <stdlib.h>
+
+#define BETA_K(d, k) 2*((1.0*d-k+1)/(d*(d+1)))
+
+// This implementation is expecting strings of sequences, that means
+// When called from Python, numpy array rows should be converted to strings
+// first and later encoded, what adds an unnecessary overhead to the process.
+long double cgo_get_K_value1(char *xi, char *xj, int L, int d)
+{
+    long double E1, beta;
+    int E2;
+    int k, l, j, eq;
+    E1 = 0.0L;
+    for (k=1; k<d+1; k++)
+    {
+        beta = BETA_K(d, k);
+        E2 = 0;
+        for (l=0; l<L-k+1; l++)
+        {
+            eq = 1;
+            for (j=l; j<l+k; j++)
+            {
+                if (xi[j]!=xj[j]) 
+                {
+                    eq = 0;
+                    break;
+                }
+            }
+            E2 += eq;
+        }
+        E1 += beta*E2;
+    }
+    return E1;
+}
+
+// This implementation should be slightly faster than previous, but in
+// practice it seems that it is only faster for d<=25. For bigger values
+// this implementation is slower than previous.
+// Still with the problem of numpy rows conversion.
+long double cgo_get_K_value2(char *xi, char *xj, int L, int d)
+{
+    long double E1, beta;
+    int E2;
+    int k, l, j;
+    char *xi_iniseq, *xj_iniseq;
+    char *xi_currpos, *xj_currpos;
+    E1 = 0.0L;
+    for (k=1; k<d+1; k++)
+    {
+        beta = BETA_K(d, k);
+        E2 = 0;
+        for (l=0, xi_iniseq=xi, xj_iniseq=xj; l<L-k+1; l++, xi_iniseq++, xj_iniseq++)
+        {
+            for (j=l,   xi_currpos=xi_iniseq, xj_currpos=xj_iniseq;
+                 j<l+k && *xi_currpos==*xj_currpos;
+                 j++,   xi_currpos++, xj_currpos++) ;
+            // Si he llegado hasta el final
+            if (j==l+k) {
+                E2++;
+            }
+        }
+        E1 += beta*E2;
+    }
+    return E1;
+}
+
+// This is the fastest version when called from Python. Now the numpy array
+// rows can be directly passed avoiding the overhead of transforming them to
+// string and encoding them afterwards.
+long double cgo_get_K_value3(const wchar_t *xi, const wchar_t *xj, int L, int
+        d) { long double E1, beta; int E2; int k, l, j, eq;
+
+    E1 = 0.0L;
+    for (k=1; k<d+1; k++)
+    {
+        beta = BETA_K(d, k);
+        E2 = 0;
+        for (l=0; l<L-k+1; l++)
+        {
+            eq = 1;
+            for (j=l; j<l+k; j++)
+            {
+                if (xi[j]!=xj[j]) 
+                {
+                    eq = 0;
+                    break;
+                }
+            }
+            E2 += eq;
+        }
+        E1 += beta*E2;
+    }
+    return E1;
+}
+
+
+int darray[] = {1, 2, 4};
+int karray[] = {3, 4, 5};
+
+// Testing that beta values are the same as in Python version
+void test1()
+{
+    int d, k, dval, kval;
+    for (d=0; d<3; d++)
+    {
+        dval = darray[d];
+        for (k=0; k<3; k++)
+        {
+            kval = karray[k];
+            printf("beta_k(%d, %d): %f\n", dval, kval, BETA_K(dval, kval));
+        }
+    }
+
+}
+
+char * SEQ1 = "CGGTACACGACGGTGTGACCTGTGATGCGGCAGGAAGCCGCTCCCATGCCTTCCGCTAAATTATACGAGACGAGCGGTTAGGCACATAATTGAATCTGCTGCTGTCGATCGCTAAGCATCCGACTCGTGAATCATATAAACATGTCTACTTATGATCAATCAATCCCCCCTCACATTGAATCCGAGCTCCGTGACATCACATGGGATTTCGTAATTTGCATGTGACGACAGCAGTCCTACCCCATTTGCCTGAGCTATTTGTGGCACGGATAGCCCGCTCCTACGCCTGGTTTCTTACTACGCTGCGCGAAGGTCGTCTTTGGCTCTACAGACTGGTCTTGACCGGCCCTTCCAGATAGAGGCCGGACAGCGTGGCCTCTTCATGCGAAAATTCGGCAGGAGGGGTAGGGACGGGGACAATAGACAGCCATCTATCGTAGAAAACCCCACTGACTGGGATGGACCAGCAGCTGGGAGCTAGACCGAGGAAGCAGTCCGACCCGAGGTAGCCTCTGCTCGCCCGCGGCTGCACCGGAGGACTTTACAGTGGAATTCAAGTATCAGATAACTTGGTGTCGTCTACTCAGAGAACTTAATTACAATATCCTACCCCGCCCCGAGGCAATTGTTCTAGTTAGAGCCTAATCTACGTGTAGGGCGACGAGTACTTATTGGCCAGCATAGCTGGTAGCCTATCGGGGGTTCCATCGAACCACGGCTATCGCAGTACATGAACAAATGACCCGCCTGCATACTAACGGTCTCTATGAAACAAATTTATACTTAGTGATATCTACCATCTAAAGTTCGGCTCTAACTGTTCGCCGTCCGATAAGTGCTCGGAGGCGTGCAACAGGCCCAACCGTGAAGACCTTTAACCCATCCAAGACTATGTGCGGAATGGTTATGCACGCACGTATCGTCATGCCCTTTCGATTCCCTCGGCTCTCGCAAACGGAGTCCGTAGGCGAAGCGCGCGATGAAGGTAGGGGACGGAACCTGT";
+
+char * SEQ2 = "ACGACCCGTGGGATTCTCTTTCTCCACAATTCACTGGGCCTTTAACCCGAATAACCTTCGATCGCTCCTACATCTTTTAGCTCCGCACTTGCGTTAGCGTAGAGGGGGCACCCGCTTTGCGGCGACCATCCAACTTCGTAGCTTGGTCGCGTGCGACAATGTCTCTACACTCACTGGAGATTGGCCTACAGCACTACCTATACACGGGGGAGCATCCCTAAAGCCTTTCCCTTGTCTGGGAGCCGCGGCGAATTCGAAGACTAGAGACTAGTAGCCGGATAGTCCGCAAGGAGCTCATTGCTGCACGAAACTAAACTCTCAAACCGCCCAAAAGTGATATCGAGATGCTGCACACTCAAGCTGACTACCCGGTTTCAGTATGTACACTGATAGCGATTACTAATCAACCCAGTACGTTGTTAGGATATCAATCGGTTTGCGTTGATGGACAGCGGCGGCAAATCCGGACATTATCAAACATAAGTCAGGTCTGTCCCGGCAGGGTGATCGGCCTCTGCCTAAGAATGGGGATCTGGATTGGCCACTGAAGATGAAGTTCTGTGTAAAAATGCTGTGTTCGCCACAATACTGCTGTGTCGTCGAGATGCGGCAGTTGGGATCTTACCCACACTCCGGCGACGTGGAGATCCTTTATTGGCGTACTCGCCGACTATTCGGTGAGGACGATAACCCTTGTGCTCAGCTCCGGATACGTAATCCCTAGGAGAGTTCTTCTCTCTTGAACTGTTATCGGGTACTGCCGTACTCGCATGGCCGGTGCGATTATCCCAGTCCCCTAAGAACCAGATGTTGTACGGCGACCTAGGGGCGAGCGTTTTTTGTGACAATATCCACTAGCCTGATCGCATGTTAGGAGTAGGACTACTATTACACCGGCGTTACTAGGTAAATTTGGATAGGGTTTGCGGTAGCACAGACATAAACAGGACACAAGATGGTCTACCCACTACTCGCATTGGACCTGATGGTCGCGTCCACTATC";
+
+/* char * SEQ1 = "AAGGTTAAGGTT"; */
+/* char * SEQ2 = "AGGTTTAGGTTT"; */
+/* char * SEQ1 = "AAGGTT"; */
+/* char * SEQ2 = "AGGTTT"; */
+
+
+// Utility function to get longer sequences by replicating one char string
+char * repstr(char *input, int n)
+{
+    char * output = (char *)malloc(strlen(input)*n+1);
+    if (n<1) {
+        fprintf(stderr, "Number of replications should be larger than 0.");
+        exit(-1);
+    }
+    strcpy(output, input);
+    for(int i=1; i<n; i++) strcat(output, input);
+    return output;
+}
+
+// Testing the times and that the results are always the same.
+// The results are not too meaningful as here the methods are only
+// compared in one sequence. The actual improvements will be seen when
+// used within the calculation of the Kernel matrix in Python. There
+// implementation 3 is clearly the winner as it avoids the overhead
+// of transforming the numpy rows arrays into char strings.
+void test2()
+{
+    int L, d;
+    long double res;
+    clock_t start, end;
+    double time1, time2, time3;
+    char * seq1, *seq2; 
+
+    int n=5;
+
+    seq1 = repstr(SEQ1, n);
+    seq2 = repstr(SEQ2, n);
+
+    L = strlen(seq1);
+    d = (int)((float)L * 0.7);
+    printf("L: %d, d: %d\n", L, d);
+
+    start = clock();
+    res = cgo_get_K_value1(seq1, seq2, L, d);
+    end = clock();
+    time1 = ((double) (end - start)) / CLOCKS_PER_SEC;
+    printf("Res: %Lf in %f secs\n", res, time1);
+
+    start = clock();
+    res = cgo_get_K_value2(seq1, seq2, L, d);
+    end = clock();
+    time2 = ((double) (end - start)) / CLOCKS_PER_SEC;
+    printf("Res: %Lf in %f secs\n", res, time2);
+
+    // Transforming char string into wchar strings
+    wchar_t seq1wchar[L+1];
+    wchar_t seq2wchar[L+1];
+    mbstowcs(seq1wchar, seq1, L);
+    mbstowcs(seq2wchar, seq2, L);
+    
+    start = clock();
+    res = cgo_get_K_value3(seq1wchar, seq2wchar, L, d);
+    end = clock();
+    time3 = ((double) (end - start)) / CLOCKS_PER_SEC;
+    printf("Res: %Lf in %f secs\n", res, time3);
+
+    printf("Version 3 is %f times faster than version 1\n", time1/time3);
+    printf("Version 3 is %f times faster than version 2\n", time2/time3);
+
+    free(seq1);
+    free(seq2);
+}
+
+int main()
+{
+    test2();
+    return 0;
+}


### PR DESCRIPTION
I have implemented the calculations of the string kernel in C to create a library that can be called from Python and run everything faster. The impact of the increase of speed depends on the number and size of the sequences and on the value of the parameter d that controls de maximum length of the considered k-mers. For example, for 100 sequences of length 2003 and a d=20, the new version is six times faster than the previous version (in my laptop I have used 4 cores, the number of cores could have also influenced in the final results).

Also, I have added additional optional parameters to values that before were global values. 